### PR TITLE
Split the content into chunks when it is too long for the API

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -13,10 +13,19 @@ export default class Analyzer {
   /** Perspective API URL */
   private apiUrl: string
 
+  /** Length of a chunk of content when it needs to be broken up because it is too long */
+  private chunkLength: number
+
   /** Probot logger */
   private log: Logger
 
-  constructor(logger: Logger) {
+  /** Maximum length of content that can be processed by the analysis API */
+  private maxLength: number
+
+  /** Amount of content to slice off that is less than the length of a chunk so they overlap */
+  private sliceLength: number
+
+  constructor(logger: Logger, maxLength = 3000) {
     if (!process.env.PERSPECTIVE_KEY) {
       throw new InvalidEnvironmentError('PERSPECTIVE_KEY')
     }
@@ -25,17 +34,44 @@ export default class Analyzer {
 
     this.apiUrl = `https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=${key}`
     this.log = logger
+
+    this.maxLength = maxLength
+
+    // Create some overlap in the chunks so that toxicity can't hide on borders between chunks
+    const overlapLength = Math.floor(this.maxLength / 6)
+    this.chunkLength = this.maxLength - overlapLength
+    this.sliceLength = this.maxLength - (overlapLength * 2)
   }
 
   /**
    * Analyzes the event in `info` and returns a toxicity value in the range `[0,1]`.
+   *
+   * If the text in `info.content` is [too long](https://github.com/atom/biohazard-alert/issues/1):
+   *
+   * 1. The text is split into chunks
+   * 2. Each chunk is analyzed separately
+   * 3. The highest score for a chunk is returned as the score for the event
    */
   async analyze(info: EventInfo): Promise<number> {
+    const chunks = this.split(info.content)
+    const scores = await Promise.all(chunks.map(async chunk => {
+      return this.analyzeChunk(info, chunk)
+    }))
+
+    this.log.debug(scores, `Toxicity values for chunks of ${info.source}`)
+
+    return Math.max(...scores)
+  }
+
+  /**
+   * Analyzes a chunk of the content and returns a toxicity value in the range `[0,1]`.
+   */
+  private async analyzeChunk(info: EventInfo, chunk: string): Promise<number> {
     const apiRequest = {
       url: this.apiUrl,
       body: {
         comment: {
-          text: info.content
+          text: chunk
         },
         doNotStore: info.isRepoPrivate,
         requestedAttributes: {
@@ -45,10 +81,29 @@ export default class Analyzer {
       json: true
     }
 
-    this.log.debug(`Call Perspective API on ${info.source}`)
+    this.log.debug(request, `Call Perspective API on ${info.source}`)
     const response = await (request.post(apiRequest) as any)
     this.log.debug(response, `Perspective API response for ${info.source}`)
 
     return response.attributeScores.TOXICITY.summaryScore.value
+  }
+
+  /**
+   * Splits `content` into an array of strings each short enough to be processed by the API.
+   */
+  private split(content: string): string[] {
+    let chunks: string[] = []
+
+    while (content.length > this.maxLength) {
+      let chunk = content.slice(0, this.chunkLength)
+
+      chunks.push(chunk)
+
+      content = content.slice(this.sliceLength, -1)
+    }
+
+    chunks.push(content)
+
+    return chunks
   }
 }


### PR DESCRIPTION
Fixes #1 

Sample output:

```
20:33:45.985Z DEBUG probot:
  [ 0.15932652,
    0.129621,
    0.06664747,
    0.048457928,
    0.04277194,
    0.029872794,
    0.032037634,
    0.182867,
    0.041359097,
    0.066919856,
    0.1160152,
    0.12291909,
    0.081217416,
    0.044088513,
    0.05226184,
    0.08034727,
    0.04365614,
    0.02940446,
    0.01244499,
    0.008203746,
    0.014509968,
    0.008693565,
    0.034518994,
    0.028158067,
    0.06605402,
    0.023918264,
    0.017198592,
    0.012413225,
    0.04678592,
    0.011506656,
    0.025654588,
    0.041865177,
    0.01669097,
    0.027571227,
    0.034080464,
    0.042048357,
    0.2080453,
    0.27854547,
    0.27781987,
    0.20551279,
    0.14628157,
    0.094232835,
    0.05785275 ] 'Toxicity values for chunks of [[test issue]]'
20:33:45.986Z  INFO probot: Toxicity score 0.27854547 for [[test issue]]
```