### PR TITLE
Add experimental sentiment analysis models

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-Listens for new or edited issues, pull requests, or comments. It sends the content of those events to a semantic analysis API that can rate the toxicity of the content. If the toxicity is rated above a threshold, a notification email is sent.
+Listens for new or edited issues, pull requests, or comments. It sends the content of those events to a semantic analysis API that can rate the content on multiple sentiment axes. If the content is rated above a threshold on any axis, a notification email is sent to humans to investigate and decide whether to take action.
 
 ## Configuration
 
@@ -16,7 +16,21 @@ This Probot app reads its configuration from two files:
 Configuration settings are:
 
 * `skipPrivateRepos`: `true` means that events from private repositories will be ignored (**default** `true`)
-* `toxicityThreshold`: Toxicity ratings higher than this number will generate notifications (**default** `0.8`)
+* `threshold`: Analysis ratings higher than this number will generate notifications (**default** `0.8`)
+
+## Analysis
+
+This app uses [Google's Perspective API](https://www.perspectiveapi.com/#/) to analyze the content using the following [models](https://github.com/conversationai/perspectiveapi/blob/master/api_reference.md#models):
+
+* `TOXICITY`
+* `SEVERE_TOXICITY`
+* `IDENTITY_ATTACK`
+* `INSULT`
+* `PROFANITY`
+* `THREAT`
+* `SEXUALLY_EXPLICIT`
+* `FLIRTATION`
+* `UNSUBSTANTIAL`
 
 ## Development
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -95,7 +95,15 @@ export default class Analyzer {
         },
         doNotStore: info.isRepoPrivate,
         requestedAttributes: {
-          TOXICITY: {}
+          TOXICITY: {},
+          SEVERE_TOXICITY: {},
+          IDENTITY_ATTACK: {},
+          INSULT: {},
+          PROFANITY: {},
+          THREAT: {},
+          SEXUALLY_EXPLICIT: {},
+          FLIRTATION: {},
+          UNSUBSTANTIAL: {}
         }
       },
       json: true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,15 @@ import Octokit from '@octokit/rest'
 
 import Analyzer from './analyzer'
 
+interface Options {
+  verbose: boolean
+}
+
 type IssueOrComment = Octokit.IssuesGetResponse | Octokit.IssuesGetCommentResponse
 type Repo = Octokit.ReposGetResponse
 type User = Octokit.IssuesGetResponseUser | Octokit.IssuesGetCommentResponseUser
+
+type ScoreMap = {[s: string]: number}
 
 // Disable Probot logging
 const logger = {
@@ -32,11 +38,18 @@ export default class Cli {
    */
   async run () {
     try {
-      const [options, info] = await this.parseArguments() // eslint-disable-line no-unused-vars
+      const [options, info] = await this.parseArguments()
 
       const analysis = await this.analyzer.getAnalysis(info)
-      analysis.forEach(report => {
-        console.log(JSON.stringify(report, null, 2))
+      analysis.forEach(response => {
+        if (options.verbose) {
+          console.log(JSON.stringify(response, null, 2))
+        } else {
+          const scores = this.getScores(response)
+
+          Object.keys(scores).sort().forEach(key => { console.log(`${key}: ${scores[key]}`)})
+          console.log('')
+        }
       })
     } catch (e) {
       console.error(e)
@@ -63,12 +76,30 @@ export default class Cli {
     return `${event}.${action}`
   }
 
+  private getScores (response: Perspective.Response): ScoreMap {
+    const attrScores = response.attributeScores
+    let scores: ScoreMap = {}
+
+    Object.keys(attrScores).forEach(key => {
+      scores[key] = attrScores[key].summaryScore.value
+    })
+
+    return scores
+  }
+
   private isBot (user: User): boolean {
     return user.type !== 'User'
   }
 
-  private async parseArguments (): Promise<[object, EventInfo]> {
-    const options = require('yargs').argv
+  private async parseArguments (): Promise<[Options, EventInfo]> {
+    const options =
+      require('yargs')
+      .usage('Usage: $0 [options] url')
+      .boolean('verbose')
+      .alias('v', 'verbose')
+      .describe('v', 'Write out the full API response')
+      .argv
+
     const info = await this.parseUri(options._)
 
     return [options, info]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ export default class Cli {
         } else {
           const scores = this.getScores(response)
 
-          Object.keys(scores).sort().forEach(key => { console.log(`${key}: ${scores[key]}`)})
+          Object.keys(scores).sort().forEach(key => { console.log(`${key}: ${scores[key]}`) })
           console.log('')
         }
       })
@@ -94,11 +94,11 @@ export default class Cli {
   private async parseArguments (): Promise<[Options, EventInfo]> {
     const options =
       require('yargs')
-      .usage('Usage: $0 [options] url')
-      .boolean('verbose')
-      .alias('v', 'verbose')
-      .describe('v', 'Write out the full API response')
-      .argv
+        .usage('Usage: $0 [options] url')
+        .boolean('verbose')
+        .alias('v', 'verbose')
+        .describe('v', 'Write out the full API response')
+        .argv
 
     const info = await this.parseUri(options._)
 

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -5,6 +5,8 @@ import stripIndent from 'strip-indent'
 
 import InvalidEnvironmentError from './invalid-environment-error'
 
+type Scores = {[s: string]: number}
+
 /**
  * Sends notifications via Sendgrid to the configured email addresses.
  *
@@ -59,14 +61,16 @@ export default class Notifier {
   /**
    * Sends a notification of the `score` ascribed to `info` to the notification email address.
    */
-  async notify (info: EventInfo, score: number): Promise<void> {
-    this.log.debug(info, `Notify subscribers of score ${score} on ${info.source}`)
+  async notify (info: EventInfo, scores: Scores): Promise<void> {
+    this.log.debug(info, `Notify subscribers of scores ${JSON.stringify(scores)} on ${info.source}`)
 
     const text = `
 ## Biohazard Alert
 
-${this.sourceLink(info)} by ${this.authorLink(info)} was found
-with a toxicity of ${score}. Please investigate!
+${this.sourceLink(info)} by ${this.authorLink(info)} has scores that exceeded the designated
+threshold. Please investigate!
+
+${this.formatScores(scores)}
 
 Original text follows:
 
@@ -109,6 +113,16 @@ ${info.content}
 
   private authorLink (info: EventInfo): string {
     return `[${info.author}](https://github.com/${info.author})`
+  }
+
+  private formatScores (scores: Scores): string {
+    let text = ''
+
+    for (let attr in scores) {
+      text += `* **${attr}:** ${scores[attr]}\n`
+    }
+
+    return text
   }
 
   private toHtml (text: string): string {


### PR DESCRIPTION
Fixes #7 

This required rewriting the analysis and notification pipelines to handle more than one score. This will make it easier in the future to support more than just one API for sentiment analysis if we decide to do so.