### PR TITLE
Strips email comment blocks from content to be analyzed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 npm-debug.log
 debug.log
 .env
+
+# Ignore TypeScript incremental build files
+**/.tsbuildinfo

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -56,6 +56,8 @@ export default class Analyzer {
    * 3. The highest score for a chunk is returned as the score for the event
    */
   async analyze (info: EventInfo): Promise<Scores> {
+    this.log.debug(info, 'Analyze event')
+
     const responses = await this.getAnalysis(info)
     const allScores = this.extractScores(responses)
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -3,8 +3,7 @@ import * as request from 'request-promise-native'
 
 import InvalidEnvironmentError from './invalid-environment-error'
 
-type AllScores = {[s: string]: number[]}
-type Scores = {[s: string]: number}
+type AllScores = {[modelName: string]: number[]}
 
 /**
  * Analyzes text for toxicity and other attributes.

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -114,8 +114,6 @@ export default class Handler {
         }
 
       case 'commit_comment.created':
-      case 'issue_comment.created':
-      case 'issue_comment.edited':
         return {
           author: context.payload.comment.user.login,
           event: context.event,
@@ -126,9 +124,28 @@ export default class Handler {
           content: context.payload.comment.body
         }
 
+      case 'issue_comment.created':
+      case 'issue_comment.edited':
+        return {
+          author: context.payload.comment.user.login,
+          event: context.event,
+          fullEvent: fullEvent,
+          isBot: context.isBot,
+          isRepoPrivate: context.payload.repository.private,
+          source: context.payload.comment.html_url,
+          content: this.stripEmailReply(context.payload.comment.body)
+        }
+
       default: {
         return null
       }
     }
+  }
+
+  private stripEmailReply (content: string): string {
+    const replyBlockPattern = /(^>.*$\n?)+/m
+    const match = replyBlockPattern.exec(content)
+
+    return match ? content.slice(0, match.index) : content
   }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -143,7 +143,7 @@ export default class Handler {
   }
 
   private stripEmailReply (content: string): string {
-    const replyBlockPattern = /(^>.*$\n?)+/m
+    const replyBlockPattern = /(^.*<[^@]+@[^>]+>.*:$\n\n)?(^>.*$\n?)+/m
     const match = replyBlockPattern.exec(content)
 
     return match ? content.slice(0, match.index) : content

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,13 +3,18 @@ import { Context, Logger } from 'probot' // eslint-disable-line no-unused-vars
 import Analyzer from './analyzer'
 import Notifier from './notifier'
 
+/**
+ * Configuration information.
+ */
 interface Config {
+  /** Flag indicating whether to ignore events from private repos. */
   skipPrivateRepos: boolean
+
+  /** Value over which to send a notification. Ranges from [0,1]. */
   threshold: number
 }
 
 type GetConfig = (context: Context, filename: string, defaults: Config) => Config
-type Scores = {[s: string]: number}
 
 const getConfig = require('probot-config') as GetConfig
 
@@ -83,6 +88,11 @@ export default class Handler {
     }
   }
 
+  /**
+   * Determines whether any of the `scores` are over the `threshold`.
+   *
+   * Returns only the scores that exceed the threshold or `null` if none of them did.
+   */
   private isOverThreshold (scores: Scores, threshold: number): Scores | null {
     let thresholdScores: Scores = {}
     let crossedThreshold = false
@@ -97,6 +107,11 @@ export default class Handler {
     return crossedThreshold ? thresholdScores : null
   }
 
+  /**
+   * Parses the important bits out of `context`.
+   *
+   * Returns an `EventInfo` structure or `null` if the event represented is not supported.
+   */
   private parseContext (context: Context): EventInfo | null {
     const fullEvent = `${context.event}.${context.payload.action}`
 
@@ -142,6 +157,11 @@ export default class Handler {
     }
   }
 
+  /**
+   * Strips an email reply block from the end of `content`.
+   *
+   * Returns everything but the email reply block.
+   */
   private stripEmailReply (content: string): string {
     const replyBlockPattern = /(^.*<[^@]+@[^>]+>.*:$\n\n)?(^>.*$\n?)+/m
     const match = replyBlockPattern.exec(content)

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -5,8 +5,6 @@ import stripIndent from 'strip-indent'
 
 import InvalidEnvironmentError from './invalid-environment-error'
 
-type Scores = {[s: string]: number}
-
 /**
  * Sends notifications via Sendgrid to the configured email addresses.
  *

--- a/src/scores.ts
+++ b/src/scores.ts
@@ -1,0 +1,6 @@
+/**
+ * Holds scores for a set of models.
+ */
+interface Scores {
+  [modelName: string]: number
+}


### PR DESCRIPTION
Because it wouldn't be fair for someone to get graded down by replying to toxicity if their reply wasn't itself toxic.

Fixes #8 